### PR TITLE
Updating master with updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-/target
-**/*.rs.bk
 **/*.swp
-**/*.rustfmt


### PR DESCRIPTION
imports io::Error with self to avoid confusion. .gitignore in the root dir now only has .swp files excluded.  Fixed unit tests